### PR TITLE
test(entries): Extend map grid data

### DIFF
--- a/schema-template/entry.json
+++ b/schema-template/entry.json
@@ -4,7 +4,7 @@
 
 	"title": "Entry",
 	"description": "A recursively renderable object.",
-	"version": "1.8.3",
+	"version": "1.8.4",
 
 	"$defs" : {
 		"_arrayOfSpell": {
@@ -927,11 +927,20 @@
 										"hexColsEven"
 									]
 								},
-								"size": {"type": "integer"},
+								"size": {
+									"type": "integer",
+									"min": 50
+								},
 								"offsetX": {"type": "integer"},
 								"offsetY": {"type": "integer"},
 								"scale": {
 									"description": "Map image scaling. Where possible, avoid using this, and use size/offset instead.",
+									"type": "number"
+								},
+								"units": {
+									"type": "string"
+								},
+								"distance": {
 									"type": "number"
 								}
 							},

--- a/schema/brew-fast/entry.json
+++ b/schema/brew-fast/entry.json
@@ -3,7 +3,7 @@
 	"$id": "entry.json",
 	"title": "Entry",
 	"description": "A recursively renderable object.",
-	"version": "1.8.3",
+	"version": "1.8.4",
 	"$defs": {
 		"_arrayOfSpell": {
 			"type": "array",
@@ -1682,7 +1682,8 @@
 							]
 						},
 						"size": {
-							"type": "integer"
+							"type": "integer",
+							"min": 50
 						},
 						"offsetX": {
 							"type": "integer"
@@ -1692,6 +1693,12 @@
 						},
 						"scale": {
 							"description": "Map image scaling. Where possible, avoid using this, and use size/offset instead.",
+							"type": "number"
+						},
+						"units": {
+							"type": "string"
+						},
+						"distance": {
 							"type": "number"
 						}
 					},

--- a/schema/brew/entry.json
+++ b/schema/brew/entry.json
@@ -3,7 +3,7 @@
 	"$id": "entry.json",
 	"title": "Entry",
 	"description": "A recursively renderable object.",
-	"version": "1.8.3",
+	"version": "1.8.4",
 	"$defs": {
 		"_arrayOfSpell": {
 			"type": "array",
@@ -1682,7 +1682,8 @@
 							]
 						},
 						"size": {
-							"type": "integer"
+							"type": "integer",
+							"min": 50
 						},
 						"offsetX": {
 							"type": "integer"
@@ -1692,6 +1693,12 @@
 						},
 						"scale": {
 							"description": "Map image scaling. Where possible, avoid using this, and use size/offset instead.",
+							"type": "number"
+						},
+						"units": {
+							"type": "string"
+						},
+						"distance": {
 							"type": "number"
 						}
 					},

--- a/schema/site-fast/entry.json
+++ b/schema/site-fast/entry.json
@@ -3,7 +3,7 @@
 	"$id": "entry.json",
 	"title": "Entry",
 	"description": "A recursively renderable object.",
-	"version": "1.8.3",
+	"version": "1.8.4",
 	"$defs": {
 		"_arrayOfSpell": {
 			"type": "array",
@@ -1668,7 +1668,8 @@
 							]
 						},
 						"size": {
-							"type": "integer"
+							"type": "integer",
+							"min": 50
 						},
 						"offsetX": {
 							"type": "integer"
@@ -1678,6 +1679,12 @@
 						},
 						"scale": {
 							"description": "Map image scaling. Where possible, avoid using this, and use size/offset instead.",
+							"type": "number"
+						},
+						"units": {
+							"type": "string"
+						},
+						"distance": {
 							"type": "number"
 						}
 					},

--- a/schema/site/entry.json
+++ b/schema/site/entry.json
@@ -3,7 +3,7 @@
 	"$id": "entry.json",
 	"title": "Entry",
 	"description": "A recursively renderable object.",
-	"version": "1.8.3",
+	"version": "1.8.4",
 	"$defs": {
 		"_arrayOfSpell": {
 			"type": "array",
@@ -1668,7 +1668,8 @@
 							]
 						},
 						"size": {
-							"type": "integer"
+							"type": "integer",
+							"min": 50
 						},
 						"offsetX": {
 							"type": "integer"
@@ -1678,6 +1679,12 @@
 						},
 						"scale": {
 							"description": "Map image scaling. Where possible, avoid using this, and use size/offset instead.",
+							"type": "number"
+						},
+						"units": {
+							"type": "string"
+						},
+						"distance": {
 							"type": "number"
 						}
 					},


### PR DESCRIPTION
This schema update supports implementation of PLUT-454, which will be necessary to fully set grid data through Plutonium