### PR TITLE
Support HF & HFFotM

### DIFF
--- a/schema-template/recipes.json
+++ b/schema-template/recipes.json
@@ -107,7 +107,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["alcohol"]
+						"enum": ["alcohol", "feast"]
 					}
 				},
 				"allergenGroups": {


### PR DESCRIPTION
1. Add new miscTag to identify which recipes form part of a particular themed "Heroes' Feast", supports page xvi in HF
2. Anticipated change to recipe `type` extending enum to include HFFotM categories.