### PR TITLE
test(recipe): Expand Recipe Types

### DIFF
--- a/schema-template/recipes.json
+++ b/schema-template/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"type": "object",
 
 	"$defs": {
@@ -95,7 +95,22 @@
 						"key_site": "enum",
 						"key_ua": "enum",
 						"key_brew": "examples",
-						"value": ["Dwarven", "Elven","Elixir/Ale", "Human", "Halfling", "Uncommon Cuisine"]
+						"value": [
+							"Dwarven",
+							"Elixir/Ale",
+							"Elven",
+							"Halfling",
+							"Human",
+							"Uncommon Cuisine",
+
+							"Lost in Realmspace",
+							"Ravenloft",
+							"Sigil",
+							"Solamnia",
+							"The Feywild",
+							"The Rock of Bral",
+							"The Yawning Portal"
+						]
 					}
 				},
 				"diet": {

--- a/schema/brew-fast/recipes.json
+++ b/schema/brew-fast/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"type": "object",
 	"$defs": {
 		"recipeData": {
@@ -95,11 +95,18 @@
 					"type": "string",
 					"examples": [
 						"Dwarven",
-						"Elven",
 						"Elixir/Ale",
-						"Human",
+						"Elven",
 						"Halfling",
-						"Uncommon Cuisine"
+						"Human",
+						"Uncommon Cuisine",
+						"Lost in Realmspace",
+						"Ravenloft",
+						"Sigil",
+						"Solamnia",
+						"The Feywild",
+						"The Rock of Bral",
+						"The Yawning Portal"
 					]
 				},
 				"diet": {
@@ -271,11 +278,18 @@
 							"type": "string",
 							"examples": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {
@@ -451,11 +465,18 @@
 							"type": "string",
 							"examples": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {

--- a/schema/brew/recipes.json
+++ b/schema/brew/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"type": "object",
 	"$defs": {
 		"recipeData": {
@@ -95,11 +95,18 @@
 					"type": "string",
 					"examples": [
 						"Dwarven",
-						"Elven",
 						"Elixir/Ale",
-						"Human",
+						"Elven",
 						"Halfling",
-						"Uncommon Cuisine"
+						"Human",
+						"Uncommon Cuisine",
+						"Lost in Realmspace",
+						"Ravenloft",
+						"Sigil",
+						"Solamnia",
+						"The Feywild",
+						"The Rock of Bral",
+						"The Yawning Portal"
 					]
 				},
 				"diet": {
@@ -271,11 +278,18 @@
 							"type": "string",
 							"examples": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {
@@ -451,11 +465,18 @@
 							"type": "string",
 							"examples": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {

--- a/schema/site-fast/recipes.json
+++ b/schema/site-fast/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"type": "object",
 	"$defs": {
 		"recipeData": {
@@ -101,11 +101,18 @@
 					"type": "string",
 					"enum": [
 						"Dwarven",
-						"Elven",
 						"Elixir/Ale",
-						"Human",
+						"Elven",
 						"Halfling",
-						"Uncommon Cuisine"
+						"Human",
+						"Uncommon Cuisine",
+						"Lost in Realmspace",
+						"Ravenloft",
+						"Sigil",
+						"Solamnia",
+						"The Feywild",
+						"The Rock of Bral",
+						"The Yawning Portal"
 					]
 				},
 				"diet": {
@@ -277,11 +284,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {
@@ -457,11 +471,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {

--- a/schema/site/recipes.json
+++ b/schema/site/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"type": "object",
 	"$defs": {
 		"recipeData": {
@@ -101,11 +101,18 @@
 					"type": "string",
 					"enum": [
 						"Dwarven",
-						"Elven",
 						"Elixir/Ale",
-						"Human",
+						"Elven",
 						"Halfling",
-						"Uncommon Cuisine"
+						"Human",
+						"Uncommon Cuisine",
+						"Lost in Realmspace",
+						"Ravenloft",
+						"Sigil",
+						"Solamnia",
+						"The Feywild",
+						"The Rock of Bral",
+						"The Yawning Portal"
 					]
 				},
 				"diet": {
@@ -277,11 +284,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {
@@ -457,11 +471,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {

--- a/schema/ua-fast/recipes.json
+++ b/schema/ua-fast/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"type": "object",
 	"$defs": {
 		"recipeData": {
@@ -90,11 +90,18 @@
 					"type": "string",
 					"enum": [
 						"Dwarven",
-						"Elven",
 						"Elixir/Ale",
-						"Human",
+						"Elven",
 						"Halfling",
-						"Uncommon Cuisine"
+						"Human",
+						"Uncommon Cuisine",
+						"Lost in Realmspace",
+						"Ravenloft",
+						"Sigil",
+						"Solamnia",
+						"The Feywild",
+						"The Rock of Bral",
+						"The Yawning Portal"
 					]
 				},
 				"diet": {
@@ -255,11 +262,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {
@@ -424,11 +438,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {

--- a/schema/ua/recipes.json
+++ b/schema/ua/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"type": "object",
 	"$defs": {
 		"recipeData": {
@@ -90,11 +90,18 @@
 					"type": "string",
 					"enum": [
 						"Dwarven",
-						"Elven",
 						"Elixir/Ale",
-						"Human",
+						"Elven",
 						"Halfling",
-						"Uncommon Cuisine"
+						"Human",
+						"Uncommon Cuisine",
+						"Lost in Realmspace",
+						"Ravenloft",
+						"Sigil",
+						"Solamnia",
+						"The Feywild",
+						"The Rock of Bral",
+						"The Yawning Portal"
 					]
 				},
 				"diet": {
@@ -255,11 +262,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {
@@ -424,11 +438,18 @@
 							"type": "string",
 							"enum": [
 								"Dwarven",
-								"Elven",
 								"Elixir/Ale",
-								"Human",
+								"Elven",
 								"Halfling",
-								"Uncommon Cuisine"
+								"Human",
+								"Uncommon Cuisine",
+								"Lost in Realmspace",
+								"Ravenloft",
+								"Sigil",
+								"Solamnia",
+								"The Feywild",
+								"The Rock of Bral",
+								"The Yawning Portal"
 							]
 						},
 						"diet": {


### PR DESCRIPTION
Expand recipe `type` to cover HFFotM. 

Unsure generally if "type" is the right filter group name, maybe "cuisine" or "culture" is more appropriate?