### PR TITLE
test(recipe): Extend Recipe Types supporting PaF

### DIFF
--- a/schema-template/recipes.json
+++ b/schema-template/recipes.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "recipes.json",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"type": "object",
 
 	"$defs": {
@@ -109,7 +109,18 @@
 							"Solamnia",
 							"The Feywild",
 							"The Rock of Bral",
-							"The Yawning Portal"
+
+							"The Yawning Portal",
+
+							"The Hearth",
+							"The Gilded Horseshoe",
+							"The Pink Flumph Theatre",
+							"The Low Lantern",
+							"The Halfway Inn",
+							"The Driftwood Tavern",
+							"One-Eyed Jax",
+							"The Moonstone Mask",
+							"The Hissing Stones"
 						]
 					}
 				},


### PR DESCRIPTION
`The Yawning Portal` is reused in `PaF`, hence the slightly broken up grouping.