### PR TITLE
test(Character Creation Options): Add path option type

### DIFF
--- a/schema-template/charcreationoptions.json
+++ b/schema-template/charcreationoptions.json
@@ -1,19 +1,26 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "charcreationoptions.json",
-	"version": "1.2.7",
+	"version": "1.2.8",
 	"title": "Character Creation Options",
 	"type": "object",
 
 	"$defs": {
 		"optionType": {
 			"type": "string",
-			"description": "- CS: Character Secret\n- DG: Dark Gift\n- OF: Optional Feature\n- RF:B Replacement Feature: Background\n- SG: Supernatural Gift",
+			"description": "- CS: Character Secret\n- DG: Dark Gift\n- OF: Optional Feature\n- PTH: Path\n- RF:B Replacement Feature: Background\n- SG: Supernatural Gift",
 			"$$switch_key": {
 				"key_site": "enum",
 				"key_ua": "enum",
 				"key_brew": "examples",
-				"value": ["CS", "DG", "OF", "RF:B", "SG"]
+				"value": [
+					"CS",
+					"DG",
+					"OF",
+					"PTH",
+					"RF:B",
+					"SG"
+				]
 			}
 		},
 


### PR DESCRIPTION
This could alternatively be achieved by changing the UA validation for `optionType` to `examples` rather than `enum`